### PR TITLE
Add ci skips to commit message

### DIFF
--- a/rstash
+++ b/rstash
@@ -77,7 +77,7 @@ if [ "$#" -eq 0 ]; then
     done
     git checkout -b "$BRANCH_NAME" 2>&1 | indent
     git add . 2>&1 | indent
-    git commit --no-verify -m "temporary rstash branch" 2>&1 | indent
+    git commit --no-verify -m "temporary rstash branch [ci-skip] [ci skip] [skip ci]" 2>&1 | indent
     git push -u origin "$BRANCH_NAME" 2>&1 | indent
     git checkout "$CURRENT_BRANCH" 2>&1 | indent
     git branch -D "$BRANCH_NAME" 2>&1 | indent


### PR DESCRIPTION
We for example use a hook which checks the message for "[skip ci]" and does not trigger a pipeline if present.
We want to use rstash and need it :)